### PR TITLE
IOT2000 doesn't have such Alpine Node 10.x images, use what's available

### DIFF
--- a/Dockerfile.iot2000
+++ b/Dockerfile.iot2000
@@ -1,0 +1,27 @@
+###
+# Build step
+###
+FROM balenalib/iot2000-node:6-jessie-build as build
+
+RUN JOBS=MAX npm install -g --production --silent \
+       node-red \
+       node-red-admin \
+       node-red-contrib-resinio
+
+###
+# Runtime image
+###
+FROM balenalib/iot2000-node:6-jessie-run
+
+# Defines our working directory in container
+WORKDIR /usr/src/app
+
+# Copy over the files created in the previous step, including lib/, bin/
+COPY --from=build /usr/local/bin /usr/local/bin
+COPY --from=build /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+# This will copy all files in our root to the working  directory in the container
+COPY ./app ./
+
+# server.js will run when container starts up on the device
+CMD ["bash", "/usr/src/app/start.sh"]


### PR DESCRIPTION
Use regular Debian-based Node image, and the latest one, which is
6.x for this architecture
Also, have to stick to Jessie images for now, as newer ones don't
seem to currently function.

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>